### PR TITLE
chore: typo fix particle.md

### DIFF
--- a/docs/pages/build-on-cyber/account-abstraction/particle.md
+++ b/docs/pages/build-on-cyber/account-abstraction/particle.md
@@ -35,7 +35,7 @@ The CLI will guide you through a setup process; it will prompt you to enter a pr
 
 ```
 
-The CLI will inizialize a fully configured project.
+The CLI will initialize a fully configured project.
 
 ### Configuration
 


### PR DESCRIPTION
Fixed a typo:  
- In `particle.md`, corrected `inizialize` to `initialize`.  
